### PR TITLE
fix: resolve /Zc:strictStrings compiler errors

### DIFF
--- a/lib/debugger.cc
+++ b/lib/debugger.cc
@@ -25,7 +25,7 @@ bool debugger::detatch(DWORD processId) {
 }
 
 bool debugger::setHardwareBreakpoint(DWORD processId, DWORD64 address, Register reg, int trigger, int size) {
-  char* errorMessage = "";
+  const char* errorMessage = "";
   std::vector<THREADENTRY32> threads = module::getThreads(0, &errorMessage);
 
   if (strcmp(errorMessage, "")) {

--- a/lib/dll.h
+++ b/lib/dll.h
@@ -9,7 +9,7 @@
 #include <string>
 
 namespace dll {
-  bool inject(HANDLE handle, std::string dllPath, char** errorMessage, LPDWORD moduleHandle) {
+  bool inject(HANDLE handle, std::string dllPath, const char** errorMessage, LPDWORD moduleHandle) {
     // allocate space in target process memory for DLL path
     LPVOID targetProcessPath = VirtualAllocEx(handle, NULL, dllPath.length() + 1, MEM_COMMIT, PAGE_EXECUTE_READWRITE);
 
@@ -53,7 +53,7 @@ namespace dll {
     return *moduleHandle > 0;
   }
 
-  bool unload(HANDLE handle, char** errorMessage, HMODULE moduleHandle) {
+  bool unload(HANDLE handle, const char** errorMessage, HMODULE moduleHandle) {
     HMODULE kernel32 = LoadLibrary("kernel32");
 
     if (kernel32 == 0) {

--- a/lib/functions.h
+++ b/lib/functions.h
@@ -33,7 +33,7 @@ namespace functions {
   char readChar(HANDLE hProcess, DWORD64 address);
 
   template <class returnDataType>
-  Call call(HANDLE pHandle, std::vector<Arg> args, Type returnType, DWORD64 address, char** errorMessage) {
+  Call call(HANDLE pHandle, std::vector<Arg> args, Type returnType, DWORD64 address, const char** errorMessage) {
     std::vector<unsigned char> argShellcode;
 
     std::reverse(args.begin(), args.end());

--- a/lib/memory.h
+++ b/lib/memory.h
@@ -19,8 +19,8 @@ public:
     return cRead;
   }
 
-  BOOL readBuffer(HANDLE hProcess, DWORD64 address, SIZE_T size, char* dstBuffer) {
-    return ReadProcessMemory(hProcess, (LPVOID)address, dstBuffer, size, NULL);
+  BOOL readBuffer(HANDLE hProcess, DWORD64 address, SIZE_T size, const char* dstBuffer) {
+    return ReadProcessMemory(hProcess, (LPVOID)address, (LPVOID)dstBuffer, size, NULL);
   }
 
   char readChar(HANDLE hProcess, DWORD64 address) {
@@ -70,11 +70,13 @@ public:
 
   template <class dataType>
   void writeMemory(HANDLE hProcess, DWORD64 address, dataType value, SIZE_T size) {
-	  LPVOID buffer = value;
+	  void* buffer;
 
-	  if (typeid(dataType) != typeid(char*)) {
-		  buffer = &value;
-	  }
+	  if (std::is_pointer<dataType>::value) {
+      buffer = (void*)value;
+    } else {
+      buffer = &value; 
+    }
 
 	  WriteProcessMemory(hProcess, (LPVOID)address, buffer, size, NULL);
   }

--- a/lib/module.cc
+++ b/lib/module.cc
@@ -7,12 +7,12 @@
 #include "memoryjs.h"
 
 DWORD64 module::getBaseAddress(const char* processName, DWORD processId) {
-  char* errorMessage = "";
+  const char* errorMessage = "";
   MODULEENTRY32 baseModule = module::findModule(processName, processId, &errorMessage);
   return (DWORD64)baseModule.modBaseAddr; 
 }
 
-MODULEENTRY32 module::findModule(const char* moduleName, DWORD processId, char** errorMessage) {
+MODULEENTRY32 module::findModule(const char* moduleName, DWORD processId, const char** errorMessage) {
   MODULEENTRY32 module;
   bool found = false;
 
@@ -36,7 +36,7 @@ MODULEENTRY32 module::findModule(const char* moduleName, DWORD processId, char**
   return module;
 } 
 
-std::vector<MODULEENTRY32> module::getModules(DWORD processId, char** errorMessage) {
+std::vector<MODULEENTRY32> module::getModules(DWORD processId, const char** errorMessage) {
   // Take a snapshot of all modules inside a given process.
   HANDLE hModuleSnapshot = CreateToolhelp32Snapshot(TH32CS_SNAPMODULE | TH32CS_SNAPMODULE32, processId);
   MODULEENTRY32 mEntry;
@@ -67,7 +67,7 @@ std::vector<MODULEENTRY32> module::getModules(DWORD processId, char** errorMessa
   return modules;
 }
 
-std::vector<THREADENTRY32> module::getThreads(DWORD processId, char** errorMessage) {
+std::vector<THREADENTRY32> module::getThreads(DWORD processId, const char** errorMessage) {
   HANDLE hThreadSnapshot = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, processId);
   THREADENTRY32 mEntry;
 

--- a/lib/module.h
+++ b/lib/module.h
@@ -9,9 +9,9 @@
 
 namespace module {
   DWORD64 getBaseAddress(const char* processName, DWORD processId);
-  MODULEENTRY32 findModule(const char* moduleName, DWORD processId, char** errorMessage);
-  std::vector<MODULEENTRY32> getModules(DWORD processId, char** errorMessage);
-  std::vector<THREADENTRY32> getThreads(DWORD processId, char** errorMessage);
+  MODULEENTRY32 findModule(const char* moduleName, DWORD processId, const char** errorMessage);
+  std::vector<MODULEENTRY32> getModules(DWORD processId, const char** errorMessage);
+  std::vector<THREADENTRY32> getThreads(DWORD processId, const char** errorMessage);
 
 };
 #endif

--- a/lib/process.cc
+++ b/lib/process.cc
@@ -12,7 +12,7 @@ using v8::Exception;
 using v8::Isolate;
 using v8::String;
 
-process::Pair process::openProcess(const char* processName, char** errorMessage){
+process::Pair process::openProcess(const char* processName, const char** errorMessage){
   PROCESSENTRY32 process;
   HANDLE handle = NULL;
 
@@ -38,7 +38,7 @@ process::Pair process::openProcess(const char* processName, char** errorMessage)
   };
 }
 
-process::Pair process::openProcess(DWORD processId, char** errorMessage) {
+process::Pair process::openProcess(DWORD processId, const char** errorMessage) {
   PROCESSENTRY32 process;
   HANDLE handle = NULL;
 
@@ -64,7 +64,11 @@ process::Pair process::openProcess(DWORD processId, char** errorMessage) {
   };
 }
 
-std::vector<PROCESSENTRY32> process::getProcesses(char** errorMessage) {
+void process::closeProcess(HANDLE hProcess){
+  CloseHandle(hProcess);
+}
+
+std::vector<PROCESSENTRY32> process::getProcesses(const char** errorMessage) {
   // Take a snapshot of all processes.
   HANDLE hProcessSnapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, NULL);
   PROCESSENTRY32 pEntry;

--- a/lib/process.h
+++ b/lib/process.h
@@ -17,10 +17,10 @@ public:
   process();
   ~process();
 
-  Pair openProcess(const char* processName, char** errorMessage);
-  Pair openProcess(DWORD processId, char** errorMessage);
+  Pair openProcess(const char* processName, const char** errorMessage);
+  Pair openProcess(DWORD processId, const char** errorMessage);
   void closeProcess(HANDLE hProcess);
-  std::vector<PROCESSENTRY32> getProcesses(char** errorMessage);
+  std::vector<PROCESSENTRY32> getProcesses(const char** errorMessage);
 };
 
 #endif


### PR DESCRIPTION
Fix string literal conversion warnings by ensuring proper const char* usage