### PR TITLE
fix: replace deprecated fail_on_error with fail_level in biome action

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,4 +13,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review
-          fail_level: false
+          fail_level: any

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,3 +13,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review
+          fail_level: false


### PR DESCRIPTION
- Update mongolyy/reviewdog-action-biome config to use fail_level: false
- This replaces the deprecated fail_on_error parameter while maintaining the same behavior