### PR TITLE
fix: set fetch-depth: 0 for full git history in version bump

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -5,6 +5,7 @@ permissions:
   pull-requests: write
   packages: write
   security-events: write # Required for CodeQL to upload results
+  
 
 on:
   workflow_dispatch:
@@ -68,6 +69,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       
       - name: Bump package
         run: |


### PR DESCRIPTION
- Ensure complete git history is available for version operations
- Keep only essential workflow permissions